### PR TITLE
Fix critical dependency vulnerability and update package test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "shadcn-ui-mcp-server",
-  "version": "1.0.0",
+  "name": "@jpisnice/shadcn-ui-mcp-server",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shadcn-ui-mcp-server",
-      "version": "1.0.0",
+      "name": "@jpisnice/shadcn-ui-mcp-server",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.16.0",
@@ -790,14 +790,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/test-package.sh
+++ b/test-package.sh
@@ -12,7 +12,7 @@ echo "✅ Testing --help flag..."
 ./build/index.js --help > /dev/null
 echo "   Help command works!"
 
-# Test 2: Version command  
+# Test 2: Version command
 echo "✅ Testing --version flag..."
 VERSION=$(./build/index.js --version)
 echo "   Version: $VERSION"
@@ -48,8 +48,8 @@ fi
 echo "✅ Testing build files..."
 REQUIRED_FILES=(
     "build/index.js"
-    "build/handler.js" 
-    "build/tools.js"
+    "build/handler.js"
+    "build/tools/index.js"
     "build/utils/axios.js"
 )
 


### PR DESCRIPTION
## Issue

### Vulnerability

I wanted to run the MCP server locally. Once I installed packages I saw the information about the critical severity vulnerability:

```bash
npm install

added 155 packages, and audited 156 packages in 996ms

36 packages are looking for funding
  run `npm fund` for details

1 critical severity vulnerability
```

### Fixing tests

I've run the tests and they seems outdated. I've fixed the single place so the tests are correctly reflecting the code.

## Solution

I've run the npm's audit to fix that:

```bash
npm audit fix

changed 1 package, and audited 156 packages in 955ms

36 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

NPM also automatically fixed to package name in the correct one.

This upgrade updated the `form-data` to 4.0.4.

Regarding the tests, I've just updated the path to the `tools` index file.

Please let me know what do you think.

## Tests

After those fixes I've run commands:

```bash
npm run build

npm run test

npm start
```

✅ Tests went correct
✅ Then I've configured this locally running MCP server in Zed and tested if everything works fine.
